### PR TITLE
Improve scripts and save report to the local file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,4 @@ FIRECRAWL_API_KEY=xxx # You can get a key at https://www.firecrawl.dev/app
 DEEPSEEK_API_KEY=sk-e6
 DOC_PATH="./my-docs"
 DOCUMENT_URLS=https://yourdocument1.docx,https://yourdocument2.pdf
+REPORT_PATH="./reports"

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,17 +1,15 @@
-# Deep Reseach Usage Guide
+# Deep Research Usage Guide
 
 ## Run with web mode
 
 This mode only gets the data source from the Internet with the search engine and crawler.
 
 ```bash
+# Basic web mode
 ./run.sh
-```
 
-or
-
-```bash
-./run.sh --report-source web
+# With explicit argument and word limit
+./run.sh --report-source web --total-words 2000
 ```
 
 ## Run with local mode
@@ -21,10 +19,12 @@ This mode will get data from your files only as the data source.
 You have to set `DOC_PATH` to `./my-docs` in your `.env` file.
 Then put your documents to this folder.
 
-Run command:
-
 ```bash
+# Basic local mode
 ./run.sh --report-source local
+
+# With word limit
+./run.sh --report-source local --total-words 1500
 ```
 
 ## Run with hybrid mode
@@ -38,13 +38,24 @@ If your documents are stored online, you will put all your links to `DOCUMENT_UR
 
 Important note: If you enable `DOCUMENT_URLS`, the `DOC_PATH` will not be used.
 
-Run command:
-
 ```bash
+# Basic hybrid mode
 ./run.sh --report-source hybrid
+
+# With hybrid mode and word limit
+./run.sh --report-source hybrid --total-words 3000
 ```
 
-## Environment variable set up
+## Environment variable setup
+
+### TOTAL_WORDS
+
+Optional. Specifies the total number of words for the report. Can be set either:
+
+1. Via command line argument (takes precedence):
+   `--total-words <number>`
+2. In .env file:
+   `TOTAL_WORDS=2000`
 
 ### RETRIEVERS
 

--- a/deep_research_agent.py
+++ b/deep_research_agent.py
@@ -83,6 +83,10 @@ async def main():
         logger.error("REPORT_PATH environment variable is not set.")
         return
 
+    # Check and create report directory if it doesn't exist
+    if not os.path.exists(report_path):
+        os.makedirs(report_path)
+
     # Generate filename with timestamp
     timestamp = datetime.now().strftime("%Y-%m-%d_%I-%M%p")
     filename = f"{timestamp}.md"

--- a/deep_research_agent.py
+++ b/deep_research_agent.py
@@ -78,12 +78,17 @@ async def main():
     # Generate report
     generated_report = await researcher.write_report()
 
+    report_path = os.getenv("REPORT_PATH")
+    if report_path is None:
+        logger.error("REPORT_PATH environment variable is not set.")
+        return
+
     # Generate filename with timestamp
     timestamp = datetime.now().strftime("%Y-%m-%d_%I-%M%p")
     filename = f"{timestamp}.md"
 
     # Save report to file
-    with open(filename, "w", encoding="utf-8") as file:
+    with open(os.path.join(report_path, filename), "w", encoding="utf-8") as file:
         file.write(generated_report)
 
     logger.info(f"Report saved as {filename}")

--- a/deep_research_agent.py
+++ b/deep_research_agent.py
@@ -21,7 +21,15 @@ async def main():
                        default=ReportSource.Web.value,
                        choices=SUPPORTED_REPORT_SOURCES,
                        help='Specify data source for the report (local, web or hybrid).')
+    parser.add_argument('--total-words',
+                       type=int,
+                       help='Specify the total number of words for the report.')
     args = parser.parse_args()
+
+    # Set total words environment variable if provided
+    if args.total_words is not None:
+        logger.info(f"Setting TOTAL_WORDS to {args.total_words}.")
+        os.environ["TOTAL_WORDS"] = str(args.total_words)
 
     # Convert string to enum
     try:
@@ -72,11 +80,13 @@ async def main():
         }
     )
 
+    logger.info("Conducting research...")
     # Run research
     await researcher.conduct_research()
 
     # Generate report
     generated_report = await researcher.write_report()
+    logger.info(f"Generated report: {generated_report}")
 
     report_path = os.getenv("REPORT_PATH")
     if report_path is None:

--- a/deep_research_agent.py
+++ b/deep_research_agent.py
@@ -7,7 +7,7 @@ from logger import get_logger
 
 def convert_to_report_source(source_str: str) -> ReportSource:
     """Convert string value to ReportSource enum."""
-    return ReportSource(source_str.lower().capitalize())
+    return ReportSource(source_str.lower())
 
 SUPPORTED_REPORT_SOURCES = [ReportSource.Web.value, ReportSource.Local.value, ReportSource.Hybrid.value]
 
@@ -17,9 +17,9 @@ async def main():
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='Run deep research agent.')
     parser.add_argument('--report-source',
-                       default='web',
+                       default=ReportSource.Web.value,
                        choices=SUPPORTED_REPORT_SOURCES,
-                       help='Specify data source for the report (local, web or hybrid)')
+                       help='Specify data source for the report (local, web or hybrid).')
     args = parser.parse_args()
 
     # Convert string to enum
@@ -34,10 +34,10 @@ async def main():
         with open('prompts.txt', 'r', encoding='utf-8') as file:
             prompt = file.read().strip()
     except FileNotFoundError:
-        print("Error: prompts.txt file not found")
+        print("Error: prompts.txt file not found.")
         return
     except Exception as e:
-        print(f"Error reading prompts.txt: {e}")
+        print(f"Error reading prompts.txt: {e}.")
         return
 
     logger.info(f"Starting deep research agent with report source: {report_source.value}.")

--- a/deep_research_agent.py
+++ b/deep_research_agent.py
@@ -3,6 +3,7 @@ from gpt_researcher.utils.enum import ReportType, Tone, ReportSource
 import asyncio
 import os
 import argparse
+from datetime import datetime
 from logger import get_logger
 
 def convert_to_report_source(source_str: str) -> ReportSource:
@@ -75,8 +76,17 @@ async def main():
     await researcher.conduct_research()
 
     # Generate report
-    report = await researcher.write_report()
-    print(report)
+    generated_report = await researcher.write_report()
+
+    # Generate filename with timestamp
+    timestamp = datetime.now().strftime("%Y-%m-%d_%I-%M%p")
+    filename = f"{timestamp}.md"
+
+    # Save report to file
+    with open(filename, "w", encoding="utf-8") as file:
+        file.write(generated_report)
+
+    logger.info(f"Report saved as {filename}")
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,4 @@ python-dotenv==1.0.1
 langchain-unstructured==0.1.6
 unstructured==0.17.0
 faiss-cpu==1.10.0
+markdown-it-py==3.0.0


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation

___

### **PR Description**
- Added `--total-words` argument to specify report word count.
  - Sets `TOTAL_WORDS` environment variable if provided.

- Improved report saving functionality.
  - Created `REPORT_PATH` directory if it doesn't exist.
  - Saved reports with timestamped filenames.

- Updated `convert_to_report_source` to handle lowercase input.

- Enhanced usage guide with `--total-words` examples and environment variable details.
