### PR TITLE
Add -query-domains argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2025-03-22] [PR#59](https://github.com/KennyDizi/DRA/pull/59)
+
+### Added
+- Added `--query-domains` argument to specify query domains for the report, accepting a comma-separated list of domains.
+- Updated `README.md` to document the new `--query-domains` argument with usage examples.
+
+### Changed
+- Modified `GPTResearcher` initialization to include `query_domains` parameter for domain-specific queries.
+
 ## [2025-03-21] [PR#57](https://github.com/KennyDizi/DRA/pull/57)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Optional. Specifies the total number of words for the report. Can be set either:
 
 You can set it as a single value, eg: `RETRIEVERS="tavily"` or multiple value `RETRIEVERS="tavily,arxiv"` separate them by `,`.
 
+### QUERY DOMAINS
+
+You can specify the query domains via argument `--query-domains`, for example: `./run.sh --report-source web --query-domains "foo.com,bar.com"`
+
 ## Prompt
 
 You can put your requirements into the file `prompts/prompts.txt` or if you have multiple prompts that located in multiple files, you can specify it via argument `--prompts your_file.txt`, eg: `./run.sh --report-source web --prompts my_new_requirements.txt`

--- a/deep_research_agent.py
+++ b/deep_research_agent.py
@@ -28,6 +28,10 @@ async def main():
                        type=str,
                        default="prompts.txt",
                        help="Specify the prompts file for the report.")
+    parser.add_argument("--query-domains",
+                       type=str,
+                       default=None,
+                       help="Specify the query domains for the report.")
     args = parser.parse_args()
 
     # Set total words environment variable if provided
@@ -71,6 +75,11 @@ async def main():
     # Get retrievers from environment variable
     retrievers = os.getenv("RETRIEVERS")
 
+    query_domains = None
+    if args.query_domains is not None:
+        query_domains = args.query_domains.split(",")
+        logger.info(f"Query domains: {query_domains}")
+
     # Initialize researcher with deep research type
     researcher = GPTResearcher(
         query=prompt,
@@ -79,6 +88,7 @@ async def main():
         report_format="markdown",
         report_source=report_source.value,
         document_urls=document_urls,
+        query_domains=query_domains,
         headers={
             "retrievers": retrievers
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pydantic
 fastapi
 python-multipart
 markdown
-openai==1.68.0
+openai==1.68.2
 anthropic==0.49.0
 tiktoken==0.9.0
 gpt-researcher==0.12.12
@@ -30,9 +30,10 @@ onnxruntime==1.19.2
 json_repair
 json5
 loguru
+langchain-core==0.3.47
 langchain==0.3.21
 langchain_community==0.3.20
-langchain-deepseek==0.1.2
+langchain-deepseek==0.1.3
 langchain-openai==0.3.9
 langchain-anthropic==0.3.10
 tavily-python==0.5.1


### PR DESCRIPTION
### **PR Type**
Feature, Documentation

___

### **PR Description**
- Added `--query-domains` argument to specify query domains for the report.
  - The argument accepts a comma-separated list of domains.
  - The domains are logged and passed to the `GPTResearcher` instance.

- Updated `README.md` to document the new `--query-domains` argument.
  - Added usage example for the `--query-domains` argument.
