### PR TITLE
Update token limit for `o3` and `o4-mini`

### DIFF
--- a/.env.o3
+++ b/.env.o3
@@ -18,9 +18,9 @@ ORIGINAL_DOCS_PATH="./original-docs"
 DOCUMENT_URLS=https://yourdocument1.docx,https://yourdocument2.pdf
 REPORT_PATH="./reports"
 
-FAST_TOKEN_LIMIT=131072
-SMART_TOKEN_LIMIT=131072
-STRATEGIC_TOKEN_LIMIT=65536
+FAST_TOKEN_LIMIT=1047576
+SMART_TOKEN_LIMIT=200000
+STRATEGIC_TOKEN_LIMIT=200000
 
 UNSTRUCTURED_API_KEY=sk-proj- # https://platform.unstructured.io/app/account/api-keys
 ANTHROPIC_API_KEY=sk-ant-ap-

--- a/.env.o4-mini
+++ b/.env.o4-mini
@@ -18,9 +18,9 @@ ORIGINAL_DOCS_PATH="./original-docs"
 DOCUMENT_URLS=https://yourdocument1.docx,https://yourdocument2.pdf
 REPORT_PATH="./reports"
 
-FAST_TOKEN_LIMIT=131072
-SMART_TOKEN_LIMIT=131072
-STRATEGIC_TOKEN_LIMIT=65536
+FAST_TOKEN_LIMIT=1047576
+SMART_TOKEN_LIMIT=200000
+STRATEGIC_TOKEN_LIMIT=200000
 
 UNSTRUCTURED_API_KEY=sk-proj- # https://platform.unstructured.io/app/account/api-keys
 ANTHROPIC_API_KEY=sk-ant-ap-


### PR DESCRIPTION
### **PR Type**
Configuration

___

### **PR Description**
- Increased `FAST_TOKEN_LIMIT` for `o3` and `o4-mini` to `1047576`

- Raised `SMART_TOKEN_LIMIT` and `STRATEGIC_TOKEN_LIMIT` to `200000`

- Updated `.env.o3` and `.env.o4-mini` configuration files

- Supports larger token processing for relevant models
