### PR TITLE
Remove `SERPER_API_KEY` and `DEEPSEEK_API_KEY` from `o3` and `o4-mini` environment variables

### DIFF
--- a/.env.o3
+++ b/.env.o3
@@ -1,5 +1,4 @@
 OPENAI_API_KEY=sk-proj-
-TAVILY_API_KEY=tvly- # You can get a key at https://app.tavily.com/home
 DEEP_RESEARCH_BREADTH=6
 DEEP_RESEARCH_DEPTH=4
 DEEP_RESEARCH_CONCURRENCY=2
@@ -9,10 +8,9 @@ SMART_LLM="anthropic:claude-sonnet-4-20250514"
 STRATEGIC_LLM="openai:o3"
 EMBEDDING="openai:text-embedding-3-large"
 RETRIEVERS="tavily,arxiv" # Options: duckduckgo, bing, google, searchapi, serper, searx, arxiv
-SERPER_API_KEY=1fcd38- # You can get a key at https://serper.dev
+TAVILY_API_KEY=tvly- # You can get a key at https://app.tavily.com/home
 SCRAPER="firecrawl" # tavily_extract or firecrawl
 FIRECRAWL_API_KEY=xxx # You can get a key at https://www.firecrawl.dev/app
-DEEPSEEK_API_KEY=sk-e6
 DOC_PATH="./my-docs"
 ORIGINAL_DOCS_PATH="./original-docs"
 DOCUMENT_URLS=https://yourdocument1.docx,https://yourdocument2.pdf

--- a/.env.o4-mini
+++ b/.env.o4-mini
@@ -1,5 +1,4 @@
 OPENAI_API_KEY=sk-proj-
-TAVILY_API_KEY=tvly- # You can get a key at https://app.tavily.com/home
 DEEP_RESEARCH_BREADTH=6
 DEEP_RESEARCH_DEPTH=4
 DEEP_RESEARCH_CONCURRENCY=2
@@ -9,10 +8,9 @@ SMART_LLM="anthropic:claude-sonnet-4-20250514"
 STRATEGIC_LLM="openai:o4-mini"
 EMBEDDING="openai:text-embedding-3-large"
 RETRIEVERS="tavily,arxiv" # Options: duckduckgo, bing, google, searchapi, serper, searx, arxiv
-SERPER_API_KEY=1fcd38- # You can get a key at https://serper.dev
+TAVILY_API_KEY=tvly- # You can get a key at https://app.tavily.com/home
 SCRAPER="firecrawl" # tavily_extract or firecrawl
 FIRECRAWL_API_KEY=xxx # You can get a key at https://www.firecrawl.dev/app
-DEEPSEEK_API_KEY=sk-e6
 DOC_PATH="./my-docs"
 ORIGINAL_DOCS_PATH="./original-docs"
 DOCUMENT_URLS=https://yourdocument1.docx,https://yourdocument2.pdf


### PR DESCRIPTION
### **PR Type**
Configuration

___

### **PR Description**
- Removed `SERPER_API_KEY` from `.env.o3` and `.env.o4-mini`.

- Removed `DEEPSEEK_API_KEY` from `.env.o3` and `.env.o4-mini`.

- Ensured `TAVILY_API_KEY` is present in both environment files.

- Updated environment variable order for clarity and consistency.
