### PR TITLE
Add support `REASONING_EFFORT`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ TOTAL_WORDS=2000
 FAST_LLM="openai:gpt-4.1-2025-04-14"
 SMART_LLM="anthropic:claude-sonnet-4-20250514"
 STRATEGIC_LLM="deepseek:deepseek-reasoner"
+REASONING_EFFORT="high" # Option: low, medium, high
 EMBEDDING="openai:text-embedding-3-large"
 RETRIEVERS="tavily,arxiv" # Options: duckduckgo, bing, google, searchapi, serper, searx, arxiv
 SERPER_API_KEY=1fcd38- # You can get a key at https://serper.dev

--- a/.env.o3
+++ b/.env.o3
@@ -16,9 +16,9 @@ ORIGINAL_DOCS_PATH="./original-docs"
 DOCUMENT_URLS=https://yourdocument1.docx,https://yourdocument2.pdf
 REPORT_PATH="./reports"
 
-FAST_TOKEN_LIMIT=1047576
-SMART_TOKEN_LIMIT=200000
-STRATEGIC_TOKEN_LIMIT=200000
+FAST_TOKEN_LIMIT=33000
+SMART_TOKEN_LIMIT=64000
+STRATEGIC_TOKEN_LIMIT=100000
 
 UNSTRUCTURED_API_KEY=sk-proj- # https://platform.unstructured.io/app/account/api-keys
 ANTHROPIC_API_KEY=sk-ant-ap-

--- a/.env.o3
+++ b/.env.o3
@@ -7,6 +7,7 @@ FAST_LLM="openai:gpt-4.1-2025-04-14"
 SMART_LLM="anthropic:claude-sonnet-4-20250514"
 STRATEGIC_LLM="openai:o3"
 EMBEDDING="openai:text-embedding-3-large"
+REASONING_EFFORT="high" # Option: low, medium, high
 RETRIEVERS="tavily,arxiv" # Options: duckduckgo, bing, google, searchapi, serper, searx, arxiv
 TAVILY_API_KEY=tvly- # You can get a key at https://app.tavily.com/home
 SCRAPER="firecrawl" # tavily_extract or firecrawl

--- a/.env.o4-mini
+++ b/.env.o4-mini
@@ -16,9 +16,9 @@ ORIGINAL_DOCS_PATH="./original-docs"
 DOCUMENT_URLS=https://yourdocument1.docx,https://yourdocument2.pdf
 REPORT_PATH="./reports"
 
-FAST_TOKEN_LIMIT=1047576
-SMART_TOKEN_LIMIT=200000
-STRATEGIC_TOKEN_LIMIT=200000
+FAST_TOKEN_LIMIT=33000
+SMART_TOKEN_LIMIT=64000
+STRATEGIC_TOKEN_LIMIT=100000
 
 UNSTRUCTURED_API_KEY=sk-proj- # https://platform.unstructured.io/app/account/api-keys
 ANTHROPIC_API_KEY=sk-ant-ap-

--- a/.env.o4-mini
+++ b/.env.o4-mini
@@ -7,6 +7,7 @@ FAST_LLM="openai:gpt-4.1-2025-04-14"
 SMART_LLM="anthropic:claude-sonnet-4-20250514"
 STRATEGIC_LLM="openai:o4-mini"
 EMBEDDING="openai:text-embedding-3-large"
+REASONING_EFFORT="high" # Option: low, medium, high
 RETRIEVERS="tavily,arxiv" # Options: duckduckgo, bing, google, searchapi, serper, searx, arxiv
 TAVILY_API_KEY=tvly- # You can get a key at https://app.tavily.com/home
 SCRAPER="firecrawl" # tavily_extract or firecrawl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openai==1.82.0
+openai==1.82.1
 anthropic==0.52.1
 tiktoken==0.9.0
 gpt-researcher==0.13.3
@@ -6,7 +6,7 @@ unstructured-client==0.36.0
 unstructured==0.17.2
 unstructured-inference==1.0.2
 langchain-unstructured==0.1.6
-langchain-core==0.3.62
+langchain-core==0.3.63
 langchain==0.3.25
 langchain-community==0.3.24
 langchain-deepseek==0.1.3
@@ -14,11 +14,11 @@ langchain-openai==0.3.18
 langchain-anthropic==0.3.14
 tavily-python==0.7.3
 firecrawl-py==2.7.1
-networkx==3.4.2
+networkx==3.5
 langchain-text-splitters==0.3.8
 python-dotenv==1.1.0
 faiss-cpu==1.10.0
 markdown-it-py==3.0.0
 numpy==2.2.6
-ruff==0.11.11
+ruff==0.11.12
 python-dotenv==1.1.0


### PR DESCRIPTION
### **PR Type**
Enhancement, Dependencies, Configuration

___

### **PR Description**
- Added `REASONING_EFFORT` variable to all environment example files.
  - Allows configuration of reasoning effort as `low`, `medium`, or `high`.

- Updated token limit values for `FAST_TOKEN_LIMIT`, `SMART_TOKEN_LIMIT`, and `STRATEGIC_TOKEN_LIMIT` in `.env.o3` and `.env.o4-mini`.

- Updated dependencies in `requirements.txt`:
  - Updated `openai` from `1.82.0` to `1.82.1`.
  - Updated `langchain-core` from `0.3.62` to `0.3.63`.
  - Updated `networkx` from `3.4.2` to `3.5`.
  - Updated `ruff` from `0.11.11` to `0.11.12`.

- Improved environment configuration documentation with new options and comments.
